### PR TITLE
Misc changes

### DIFF
--- a/font-cache.lisp
+++ b/font-cache.lisp
@@ -69,16 +69,6 @@
 (defun get-font-styles (font-family)
   "Returns font styles for current @var{font-family}. For e.g. regular, italic, bold, etc."
   (declare (special *font-cache*))
-  (let ((result (list)))
-    (maphash (lambda (family value)
-               (declare (ignorable family))
-               (when (string-equal font-family family)
-                 (maphash (lambda (style pathname)
-                            (declare (ignorable pathname))
-                            (push style result)) 
-			  value)
-                 (return-from get-font-styles 
-                   (nreverse result))))
-	     *font-cache*)
-    (nreverse result)))
-
+  (alexandria:when-let ((font-styles (gethash font-family *font-cache*)))
+    (loop :for font-style :being :the :hash-keys :of font-styles
+          :collect font-style)))

--- a/font.lisp
+++ b/font.lisp
@@ -113,23 +113,16 @@
          (eql (font-underline font1) (font-underline font2))
          (eql (font-strikethrough font1) (font-strikethrough font2))
          (eql (font-overline font1) (font-overline font2)))))
-(defmethod print-object ((instance font) stream)
+
+(defmethod print-object ((font font) stream)
   "Pretty printing font object"
-  (with-slots (family style underline strikethrough
-		      overline)
-      instance
-    (if *print-readably*
-        (format stream
-                "#.(~S '~S ~S ~S ~S ~S ~S)"
-                'cl:make-instance 'font
-                :family family :style style :underline underline 
-                :strikethrough strikethrough
-                :overline overline)
-        (format stream
-                "#<'~S ~S ~S ~S ~S ~S >"
-                'font
-                :family family :style style :underline underline 
-                :strikethrough strikethrough :overline overline ))))
+  (print-unreadable-object (font stream :type t)
+    (format stream "Family: ~S Style: ~S. Underline: ~S. Overline: ~S. Strikethrough: ~S."
+            (font-family font)
+            (font-style font)
+            (font-underline font)
+            (font-overline font)
+            (font-strikethrough font))))
 
 (defmethod initialize-instance :after ((this-font font) &key)
   (let ((this-style (slot-value this-font 'style))


### PR DESCRIPTION
----

#

Hey I took a stab at using this to render fonts in Stump although I
didn't succeed while debugging I saw some low hanging fruits. I don't
think it is possible to print readably a class w/o providing a reader
macro so I removed that part of the PRINT-OBJECT.

StumpWM contrib WIP

``` lisp
(defpackage "FREETYPE-FONTS"
  (:use "CL"))
(in-package "FREETYPE-FONTS")

(defmethod stumpwm::font-exists-p ((font clx-ft2:font))
  t)

(defmethod stumpwm::open-font ((display xlib:display) (font clx-ft2:font))
  font)

(defmethod stumpwm::close-font ((font clx-ft2:font))
  (clx-ft2:close-font font))

(defmethod stumpwm::font-ascent ((font clx-ft2:font))
  (clx-ft2:font-ascent font))

(defmethod stumpwm::font-descent ((font clx-ft2:font))
  (clx-ft2:font-descent font))

(defmethod stumpwm::font-height ((font clx-ft2:font))
  (clx-ft2:font-height font))

(defmethod stumpwm::text-lines-height ((font clx-ft2:font) string)
  (loop :for char :across string
        :maximizing (clx-ft2:font-height font)))

(defmethod stumpwm::text-line-width ((font clx-ft2:font) string &key &allow-other-keys)
  (clx-ft2:text-width font string))

(defmethod stumpwm::draw-image-image-glyphs (drawable gcontext (font clx-ft2:font) x y string &rest keyword-args &key start end translate width size &allow-other-keys)
  (declare (ignorable keyword-args translate width size))
  (clx-ft2:draw-glyphs drawable gcontext x y string start end))

```